### PR TITLE
Fix map anchor redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
         <div class="list" id="staysList"></div>
       </div></div>
       <div class="card"><div class="pad">
-        <div class="sec-head"><h3 class="sec-title">Mapa</h3></div>
+        <div class="sec-head"><h3 id="mapa" class="sec-title">Mapa</h3></div>
         <div id="map" class="map-wrap" aria-label="Mapa Leaflet"></div>
       </div></div>
     </section>
@@ -553,7 +553,7 @@
     catch{ prompt('Copia manualmente:', location.href); }
   });
   document.getElementById('gotoMap').addEventListener('click', ()=>{
-    document.querySelector('a[href="#mapa"]').scrollIntoView({behavior:'smooth'});
+    document.getElementById('mapa').scrollIntoView({behavior:'smooth'});
   });
 
   // Boot


### PR DESCRIPTION
## Summary
- add `id="mapa"` anchor to map section
- ensure sticky "Mapa" button scrolls to the new anchor

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bb44151c8323b9bbf64be85f9ce3